### PR TITLE
Added language picker via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Gets dialogflow content and generates a NLP.js model that replicates its functionality. You need to export your Dialogflow service account as environment variable:
 
 ```sh
-DIALOGFLOW_CREDENTIALS=my_json_credentials.json node index.js train
+DIALOGFLOW_CREDENTIALS=my_json_credentials.json LANG=lang_code node index.js train
 ```
 
 At the end, you will have a ``dialogflow_model.nlp`` on ``model`` folder.

--- a/index.js
+++ b/index.js
@@ -39,9 +39,10 @@ const initWebhook = () => {
     })
 }
 
-switch (option) {
+(async () => {switch (option) {
     case 'train':
-        nlpjs.trainNLP();
+        await nlpjs.trainNLP();
+        process.exit();
         break;
     case 'use':
         const text = process.argv[3];
@@ -67,3 +68,4 @@ switch (option) {
         process.exit();
         break;
 }
+})();

--- a/tools/dialogflow.js
+++ b/tools/dialogflow.js
@@ -48,6 +48,8 @@ const intentToDM = dialogflowIntent => {
     };
 
     dm.intent = dialogflowIntent.displayName;
+    const hasTrainingPhrases = dialogflowIntent.trainingPhrases !== undefined;
+    if (hasTrainingPhrases) {
     dialogflowIntent.trainingPhrases.forEach(phrase => {
         let text = '';
 
@@ -58,8 +60,8 @@ const intentToDM = dialogflowIntent => {
         dm.trainingPhrases.push(text);
     });
 
-    if (dialogflowIntent.messages[0].text.text) dm.responses = dialogflowIntent.messages[0].text.text;
-
+    if (dialogflowIntent.messages && dialogflowIntent.messages[0].text.text) dm.responses = dialogflowIntent.messages[0].text.text;
+    }
     return dm;
 }
 

--- a/tools/nlp.js
+++ b/tools/nlp.js
@@ -2,7 +2,9 @@ const dialogflow = require('./dialogflow.js');
 const fs = require('fs');
 
 const { NlpManager } = require('node-nlp');
-const manager = new NlpManager({ languages: ['es'] });
+
+const lang = process.env.LANG || 'es';
+const manager = new NlpManager({ languages: [lang] });
 
 const NLP_MODEL_PATH = __dirname + '/../model/dialogflow_model.nlp';
 
@@ -22,11 +24,11 @@ const trainNLP = () => {
                 intentData = dialogflow.intentToDM(intentData);
 
                 intentData.trainingPhrases.forEach(trainingPhrase => {
-                    manager.addDocument('es', trainingPhrase, intentData.intent);
+                    manager.addDocument(lang, trainingPhrase, intentData.intent);
                 });
 
                 intentData.responses.forEach(response => {
-                    manager.addAnswer('es', intentData.intent, response);
+                    manager.addAnswer(lang, intentData.intent, response);
                 });
             });
 
@@ -41,7 +43,7 @@ const trainNLP = () => {
 
 const useNLP = userInput => {
     return new Promise((resolve, reject) => {
-        manager.process('es', userInput).then(response => {
+        manager.process(lang, userInput).then(response => {
             resolve(response);
         });
     });

--- a/tools/nlp.js
+++ b/tools/nlp.js
@@ -37,6 +37,8 @@ const trainNLP = () => {
                 manager.save(NLP_MODEL_PATH);
                 resolve();
             });
+        }).catch((error) => {
+            console.error(error);
         });
     });
 }


### PR DESCRIPTION
1. Added the ability to set your own language.
Currently, it is hardcoded to 'es'.
This allows users to set their own language via the process environment variables. 
e.g. 
`LANG=en node index.js train`


2. Added defensive checked to ensure data exists. 
It would error out with the following:
```
TypeError: Cannot read property 'forEach' of undefined
```

```
TypeError: Cannot read property '0' of undefined
```
Now, it checks to ensure the data exists before attempting to loop through it. 


3. Made main switch state async to await for results from training and exit the process when completed